### PR TITLE
Add example Jupyter notebook for frd_client

### DIFF
--- a/example.ipynb
+++ b/example.ipynb
@@ -1,0 +1,313 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using the `frd_client` Library\n",
+    "\n",
+    "This notebook demonstrates how to use the `frd_client` library to access and manage financial data from the FirstRate Data API. We will cover:\n",
+    "- Installation\n",
+    "- Initializing the client and other components\n",
+    "- Fetching data updates\n",
+    "- Loading data into Pandas DataFrames for various asset classes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installation\n",
+    "\n",
+    "You can install the `frd_client` library using pip. If you are running this notebook in Google Colab or another environment where `frd_client` is not yet installed, uncomment and run the following cell:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install frd_client"
+   ],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initializing Client Components\n",
+    "\n",
+    "To use `frd_client`, you need to initialize three main components:\n",
+    "- `FrdClient`: Handles communication with the API, authentication, and file downloads.\n",
+    "- `MetadataStore`: Tracks the last successful download date for each dataset to manage incremental updates.\n",
+    "- `UpdateScheduler`: Orchestrates data downloads based on daily, weekly, or monthly schedules.\n",
+    "\n",
+    "You'll need your `USER_ID` from FirstRate Data to initialize `FrdClient`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from frd_client.client import FrdClient\n",
+    "from frd_client.metadata import MetadataStore\n",
+    "from frd_client.scheduler import UpdateScheduler\n",
+    "\n",
+    "# IMPORTANT: \n",
+    "# 1. Replace \"YOUR_USER_ID\" with your actual FirstRate Data User ID.\n",
+    "# 2. Review and change `data_directory` and `database_path` below if needed.\n",
+    "#    Default is to create an 'frd_data' subdirectory in the current working directory.\n",
+    "\n",
+    "user_id = \"YOUR_USER_ID\" \n",
+    "data_directory = Path(\"frd_data\") # Default data directory\n",
+    "database_path = data_directory / \"metadata.db\" # Default metadata database path\n"
+    "\n",
+    "# Create the data directory if it doesn't exist\n",
+    "data_directory.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "client = FrdClient(userid=user_id, work_dir=data_directory)\n",
+    "meta = MetadataStore(db_path=database_path)\n",
+    "sched = UpdateScheduler(client, meta)\n",
+    "\n",
+    "print(\"FrdClient, MetadataStore, and UpdateScheduler initialized.\")\n",
+    "print(f\"Data will be stored in: {data_directory.resolve()}\")\n",
+    "print(f\"Metadata database is at: {database_path.resolve()}\")"
+   ],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fetching Data Updates\n",
+    "\n",
+    "The `UpdateScheduler` can be used to download new data incrementally. This is useful for keeping your local data store up-to-date without re-downloading everything.\n",
+    "\n",
+    "The scheduler supports daily, weekly, and monthly update cadences. When you run these, the scheduler checks the `MetadataStore` to see what data is missing or stale and then fetches only the necessary updates via the `FrdClient`.\n",
+    "\n",
+    "**Note:** Running these commands will attempt to connect to the FirstRate Data API and download data if updates are needed. Ensure your `USER_ID` is correctly set up in the previous step. For this example, we will call the methods, but in a real scenario, data would be downloaded if available and needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Ensure client, meta, and sched are initialized from the previous step.\n",
+    "# If you are running this cell independently, uncomment and run the initialization cell first.\n",
+    "\n",
+    "print(\"Running daily updates (if needed)...\")\n",
+    "# sched.run_daily() \n",
+    "# print(\"Daily updates check complete.\")\n",
+    "\n",
+    "print(\"\\nRunning weekly updates (if needed)...\")\n",
+    "# sched.run_weekly()\n",
+    "# print(\"Weekly updates check complete.\")\n",
+    "\n",
+    "print(\"\\nRunning monthly updates (if needed)...\")\n",
+    "# sched.run_monthly()\n",
+    "# print(\"Monthly updates check complete.\")\n",
+    "\n",
+    "print(\"\\nNote: Update calls are commented out to prevent actual downloads during this example run.\")\n",
+    "print(\"Uncomment them in your own environment to fetch data.\")"
+   ],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading Data into DataFrames\n",
+    "\n",
+    "The `frd_client.index.load_dataframe` function is a high-level utility that simplifies loading data. It checks if updates are needed (and downloads them if `FrdClient` and `MetadataStore` are configured for it), then loads the relevant CSV data into a Pandas DataFrame.\n",
+    "\n",
+    "You'll need to have Pandas installed (`pip install pandas`).\n",
+    "\n",
+    "Below are examples for various asset types. These examples demonstrate how to call `load_dataframe`. \n",
+    "**Note**: For these examples to run and fetch actual data:\n",
+    "1. Your `USER_ID` must be correctly set in the initialization step.\n",
+    "2. The `sched.run_daily()` (or weekly/monthly) commands should have been run to download the data first, OR `load_dataframe` will attempt to download it if it's the first time for that specific dataset.\n",
+    "3. The `client` and `meta` objects from the initialization step must be available.\n",
+    "\n",
+    "For demonstration purposes, the actual calls to `load_dataframe` are commented out. Uncomment them and provide valid parameters to load data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Ensure pandas is available. Uncomment the next line if you need to install it.\n",
+    "# !pip install pandas\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Ensure client and meta are initialized from the \"Initializing Client Components\" step.\n",
+    "# If you're running cells independently, re-run that cell first.\n",
+    "# For example:\n",
+    "# from pathlib import Path\n",
+    "# from frd_client.client import FrdClient\n",
+    "# from frd_client.metadata import MetadataStore\n",
+    "# user_id = \"YOUR_USER_ID\" # Replace with your ID\n",
+    "# data_directory = Path(\"frd_data\")\n",
+    "# database_path = data_directory / \"metadata.db\"\n",
+    "# client = FrdClient(userid=user_id, work_dir=data_directory)\n",
+    "# meta = MetadataStore(db_path=database_path)\n",
+    "\n",
+    "from frd_client.index import load_dataframe\n",
+    "\n",
+    "print(\"Pandas imported and load_dataframe is ready.\")\n",
+    "print(\"Make sure 'client' and 'meta' are initialized with your USER_ID and paths.\")"
+   ],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example 1: Daily Crypto Data\n",
+    "\n",
+    "Let's try to load daily data for a few cryptocurrencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example: Load daily crypto data for Bitcoin (BTC) and Ethereum (ETH)\n",
+    "try:\n",
+    "    # df_crypto = load_dataframe(\n",
+    "    #     client, meta,\n",
+    "    #     asset_type=\"crypto\",\n",
+    "    #     period=\"day\",  # or \"full\" for all available daily data\n",
+    "    #     timeframe=\"1day\",\n",
+    "    #     symbol_list=\"BTC,ETH\" # Comma-separated list of symbols\n",
+    "    # )\n",
+    "    # print(\"Crypto data loaded (example):\")\n",
+    "    # print(df_crypto.head())\n",
+    "    print(\"Crypto data loading example is commented out.\")\n",
+    "    print(\"Uncomment and provide valid parameters to run.\")\n",
+    "except Exception as e:\n",
+    "    print(f\"An error occurred (this is expected if commented out): {e}\")"
+   ],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example 2: Full ETF Data\n",
+    "\n",
+    "This example shows how to load the complete available daily history for specific ETFs, including adjustments for splits and dividends."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example: Load full ETF data for SPY and QQQ, adjusted for splits and dividends\n",
+    "try:\n",
+    "    # df_etf = load_dataframe(\n",
+    "    #     client, meta,\n",
+    "    #     asset_type=\"etf\",\n",
+    "    #     period=\"full\",\n",
+    "    #     timeframe=\"1day\",\n",
+    "    #     ticker_list=\"SPY,QQQ\",  # Comma-separated list\n",
+    "    #     adjustment=\"adj_splitdiv\"\n",
+    "    # )\n",
+    "    # print(\"ETF data loaded (example):\")\n",
+    "    # print(df_etf.head())\n",
+    "    print(\"ETF data loading example is commented out.\")\n",
+    "    print(\"Uncomment and provide valid parameters to run.\")\n",
+    "except Exception as e:\n",
+    "    print(f\"An error occurred (this is expected if commented out): {e}\")"
+   ],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example 3: Daily Stock Data for a Ticker Range\n",
+    "\n",
+    "Here, we load daily stock data for a range of tickers (e.g., all stocks starting with 'A' through 'B')."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example: Load daily stock data for tickers starting with A to B (e.g., AAPL, AMZN, BA, etc.)\n",
+    "try:\n",
+    "    # df_stock = load_dataframe(\n",
+    "    #     client, meta,\n",
+    "    #     asset_type=\"stock\",\n",
+    "    #     period=\"day\", # or \"full\"\n",
+    "    #     timeframe=\"1day\",\n",
+    "    #     ticker_range=\"A-B\", # Example: Stocks from A to B\n",
+    "    #     adjustment=\"adj_splitdiv\"\n",
+    "    # )\n",
+    "    # print(\"Stock data loaded (example):\")\n",
+    "    # print(df_stock.head())\n",
+    "    print(\"Stock data loading example is commented out.\")\n",
+    "    print(\"Uncomment and provide valid parameters to run.\")\n",
+    "except Exception as e:\n",
+    "    print(f\"An error occurred (this is expected if commented out): {e}\")"
+   ],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Handler-Specific Parameters\n",
+    "\n",
+    "Different asset types (handled by different \"Instrument Handlers\" within the client) may require or support different parameters for `load_dataframe`. Here's a summary based on the client's capabilities:\n",
+    "\n",
+    "| Asset Type  | Required/Common Kwargs for `load_dataframe`                 | Notes                                      |\n",
+    "| ----------- | ---------------------------------------------------------- | ------------------------------------------ |\n",
+    "| **stock**   | `ticker_range` (e.g., `\"A-E\"`), `timeframe`, `adjustment`   | `period` can be \"day\" or \"full\"            |\n",
+    "| **etf**     | `ticker_list` (e.g., `\"AAPL,SPY\"`), `timeframe`, `adjustment` | `period` can be \"day\" or \"full\"            |\n",
+    "| **index**   | `ticker_list`, `timeframe`                                 | `adjustment` is optional, `period` is \"day\" or \"full\" |\n",
+    "| **crypto**  | `symbol_list` (e.g., `\"BTC,ETH\"`), `timeframe`             | `period` is \"day\" or \"full\"                |\n",
+    "| **fx**      | `pair_list` (e.g., `\"EURUSD,GBPUSD\"`), `timeframe`         | `period` is \"day\" or \"full\"                |\n",
+    "| **futures** | `contract_month` (e.g., `\"2023M12\"` for Dec 2023), `timeframe` | `adjustment` is optional, `period` is \"day\" or \"full\" |\n",
+    "\n",
+    "**Common Parameters:**\n",
+    "- `client`: The `FrdClient` instance.\n",
+    "- `meta`: The `MetadataStore` instance.\n",
+    "- `asset_type`: One of \"stock\", \"etf\", \"index\", \"crypto\", \"fx\", \"futures\".\n",
+    "- `period`: Often \"day\" (for the latest daily data) or \"full\" (for the entire available history for the given `timeframe`).\n",
+    "- `timeframe`: Specifies the data frequency, e.g., \"1min\", \"5min\", \"1hour\", \"1day\".\n",
+    "- `adjustment`: For stocks, ETFs, and futures, specifies data adjustment methods like \"adj_split\", \"adj_splitdiv\", \"unadjusted\".\n",
+    "\n",
+    "Always refer to the specific handler documentation or the main `frd_client` README for the most up-to-date and detailed parameter options for each asset type. The examples above showcase some of the common use cases."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "This notebook provided a walkthrough of the `frd_client` library, covering installation, initialization, fetching updates, and loading data for various financial instruments.\n",
+    "\n",
+    "**Key Takeaways:**\n",
+    "- Initialize `FrdClient`, `MetadataStore`, and `UpdateScheduler` with your User ID and desired paths.\n",
+    "- Use `UpdateScheduler` (`run_daily()`, `run_weekly()`, `run_monthly()`) to keep your local data current.\n",
+    "- Use `load_dataframe()` to easily load data into Pandas DataFrames, specifying the asset type and relevant parameters.\n",
+    "\n",
+    "From here, you can integrate `frd_client` into your quantitative models, analytics scripts, or data dashboards. Remember to replace placeholder values like `\"YOUR_USER_ID\"` and example ticker symbols with your actual information.\n",
+    "\n",
+    "For more details, refer to the `frd_client` [README file](README.md) or the source code documentation."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This commit introduces an example Jupyter notebook (`example.ipynb`) to demonstrate the usage of the `frd_client` library.

The notebook covers the following:
- Installation of the library.
- Initialization of `FrdClient`, `MetadataStore`, and `UpdateScheduler`.
- Instructions on how to run daily, weekly, and monthly data updates.
- Detailed examples of loading data into Pandas DataFrames for various asset classes (Crypto, ETF, Stock), including explanations of handler-specific parameters.
- Placeholders and comments to guide you in adapting the notebook for your own use.

The notebook was created step-by-step, including adding an introduction, installation instructions, initialization steps, data update examples, data loading examples, parameter explanations, and a conclusion. Each section includes both markdown explanations and corresponding code cells. The notebook content is based on the information available in the project's README.md.